### PR TITLE
Add email property to user profile on creation

### DIFF
--- a/src/context/AuthContext.js
+++ b/src/context/AuthContext.js
@@ -67,6 +67,7 @@ export const AuthContextProvider = ({ children }) => {
         ...newUserProfileData,
         profilePicture: fileLocation,
         notifications: true,
+        email: user.email,
       });
       window.location.reload();
     } catch (err) {


### PR DESCRIPTION
- Adds email property to user profile when creating an account. 
  - This property will be useful when sending notifications when new events are created/deleted